### PR TITLE
Include capture timestamp in metadata files

### DIFF
--- a/files/phenocam_upload.sh
+++ b/files/phenocam_upload.sh
@@ -67,6 +67,9 @@ DATE=`date +"%a %b %d %Y %H:%M:%S"`
 # slight offset due to the time needed to adjust exposure
 DATETIMESTRING=`date +"%Y_%m_%d_%H%M%S"`
 
+# grab date and time for `.meta` files
+METADATETIME=`date -Iseconds`
+
 # substitute the values in the ftp.scr and IR_ftp.scr
 # upload scripts
 cat IR_ftp.scr | sed "s/DATETIMESTRING/$DATETIMESTRING/g" > IR_ftp_tmp.scr
@@ -108,6 +111,7 @@ if [ "$IR" = "1" ]; then
 	echo "ip_addr=$ip" >> /etc/config/metadata.txt
 	#echo "ip_ext_addr=$ip_ext_addr" >> /etc/config/metadata.txt
 	echo "mac_addr=$mac" >> /etc/config/metadata.txt
+	echo "datetime_original=\"$METADATETIME\"" >> /etc/config/metadata.txt
 
 	# dump overlay configuration to /dev/video/config0
 	# device to adjust in memory settings
@@ -147,6 +151,7 @@ if [ "$IR" = "1" ]; then
 	echo "ip_addr=$ip" >> /etc/config/metadata.txt
 	#echo "ip_ext_addr=$ip_ext_addr" >> /etc/config/metadata.txt
 	echo "mac_addr=$mac" >> /etc/config/metadata.txt
+	echo "datetime_original=\"$METADATETIME\"" >> /etc/config/metadata.txt
 
 	# dump overlay configuration to /dev/video/config0
 	# device to adjust in memory settings
@@ -192,6 +197,7 @@ else
 	echo "ip_addr=$ip" >> /etc/config/metadata.txt
 	#echo "ip_ext_addr=$ip_ext_addr" >> /etc/config/metadata.txt
 	echo "mac_addr=$mac" >> /etc/config/metadata.txt
+	echo "datetime_original=\"$METADATETIME\"" >> /etc/config/metadata.txt
 
 	# dump overlay configuration to /dev/video/config0
 	# device to adjust in memory settings


### PR DESCRIPTION
New property name derives from analogous `DateTimeOriginal` in Exif/XMP