### PR TITLE
Fix readme for non-Windows camera search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Please connect a computer and the PhenoCam to the same (wireless) router which h
 
 The easiest way to find the camera’s IP address is to install [StarDot Tools](http://www.stardot.com/downloads). Run the StarDot Tools program and click “refresh”. The camera should be detected and the camera’s IP address shown (you may have to run Tools as administrator in Windows, depending on your settings).
 
-If you are configuring your camera with a non-Windows computer there are other things you can do to find the IP address of the camera. From a Linux or Mac OS X terminal window you should be able to type the following command:
+If you are configuring your camera with a non-Windows computer there are other things you can do to find the IP address of the camera. From a Linux or Mac OS X terminal window you should be able to type the following commands (assuming `192.168.1.255` is the network broadcast address reported by `ifconfig`):
 
 ```bash
+ping -c 3 -b 192.168.1.255
 arp -a
 ```
 


### PR DESCRIPTION
The `arp` command is for inspecting cached ARP data. It does not search the network and will not help users locate a new camera on their network. 

Instead, use an open-source, cross-platform IP scanner if the StarDot Tools are not available.